### PR TITLE
[M3.8] Emit AS_events.tsv from BAM+GTF via TAPIS topology engine

### DIFF
--- a/scripts/run_tapis.py
+++ b/scripts/run_tapis.py
@@ -1037,10 +1037,16 @@ if __name__ == '__main__':
     # compute AS statistics with TAPIS-owned NetworkX topology engine
     if args.verbose:
         sys.stderr.write('Computing alternative splicing statistics\n')
-    from tapis.topology.reporting import write_as_statistics_from_gtf
+    from tapis.topology.reporting import (
+        write_as_statistics_from_gtf,
+        write_event_table_from_gtf_and_bam,
+    )
 
     assembled_gtf = os.path.join(args.outdir, 'assembled.gtf')
     as_statistics = os.path.join(args.outdir, 'AS_statistics.txt')
+    as_events = os.path.join(args.outdir, 'AS_events.tsv')
     write_as_statistics_from_gtf(assembled_gtf, as_statistics)
+    write_event_table_from_gtf_and_bam(assembled_gtf, args.bamfile, as_events)
     if args.verbose:
         sys.stderr.write('Wrote %s\n' % (as_statistics))
+        sys.stderr.write('Wrote %s\n' % (as_events))

--- a/tapis/topology/__init__.py
+++ b/tapis/topology/__init__.py
@@ -6,7 +6,13 @@ from tapis.topology.graph import (
     extract_read_exons_from_bam,
     parse_gtf_exons,
 )
-from tapis.topology.reporting import compute_as_statistics_from_gtf, write_as_statistics_from_gtf
+from tapis.topology.reporting import (
+    compute_as_statistics_from_gtf,
+    compute_events_from_transcripts,
+    write_as_statistics_from_gtf,
+    write_event_table,
+    write_event_table_from_gtf_and_bam,
+)
 
 __all__ = [
     "SpliceEvent",
@@ -17,5 +23,8 @@ __all__ = [
     "parse_gtf_exons",
     "detect_splice_events",
     "compute_as_statistics_from_gtf",
+    "compute_events_from_transcripts",
     "write_as_statistics_from_gtf",
+    "write_event_table",
+    "write_event_table_from_gtf_and_bam",
 ]

--- a/tapis/topology/events.py
+++ b/tapis/topology/events.py
@@ -12,7 +12,7 @@ from tapis.topology.graph import Exon, normalize_exons
 
 @dataclass(frozen=True)
 class SpliceEvent:
-    kind: str
+    kind: SpliceEventKind
     read_id: str
     chromosome: str
     strand: str
@@ -27,7 +27,9 @@ def detect_splice_events(
 ) -> list[SpliceEvent]:
     chromosome = str(graph.graph.get("chromosome", "unknown"))
     strand = str(graph.graph.get("strand", "+"))
-    event_index: dict[tuple[str, str, str, Exon | None, Exon | None], SpliceEvent] = {}
+    event_index: dict[
+        tuple[SpliceEventKind, str, str, Exon | None, Exon | None], SpliceEvent
+    ] = {}
     annotation_junctions = [(left, right) for left, right in graph.edges()]
 
     for read_id, observed in sorted(observed_transcripts.items()):
@@ -59,7 +61,7 @@ def detect_splice_events(
 
     return sorted(
         event_index.values(),
-        key=lambda event: (event.kind, event.read_id, event.detail),
+        key=lambda event: (event.kind.value, event.read_id, event.detail),
     )
 
 
@@ -69,7 +71,9 @@ def _collect_exon_skipping_events(
     exons: list[Exon],
     chromosome: str,
     strand: str,
-    event_index: dict[tuple[str, str, str, Exon | None, Exon | None], SpliceEvent],
+    event_index: dict[
+        tuple[SpliceEventKind, str, str, Exon | None, Exon | None], SpliceEvent
+    ],
 ) -> None:
     for left, right in pairwise(exons):
         if graph.has_edge(left, right):
@@ -90,7 +94,7 @@ def _collect_exon_skipping_events(
         _add_event(
             event_index=event_index,
             event=SpliceEvent(
-                kind=SpliceEventKind.EXON_SKIPPING.value,
+                kind=SpliceEventKind.EXON_SKIPPING,
                 read_id=read_id,
                 chromosome=chromosome,
                 strand=strand,
@@ -107,7 +111,9 @@ def _collect_alternative_splice_site_events(
     annotation_junctions: list[tuple[Exon, Exon]],
     chromosome: str,
     strand: str,
-    event_index: dict[tuple[str, str, str, Exon | None, Exon | None], SpliceEvent],
+    event_index: dict[
+        tuple[SpliceEventKind, str, str, Exon | None, Exon | None], SpliceEvent
+    ],
 ) -> None:
     for left, right in pairwise(exons):
         donor = left[1]
@@ -127,7 +133,7 @@ def _collect_alternative_splice_site_events(
         _add_event(
             event_index=event_index,
             event=SpliceEvent(
-                kind=SpliceEventKind.ALTERNATIVE_SPLICE_SITE.value,
+                kind=SpliceEventKind.ALTERNATIVE_SPLICE_SITE,
                 read_id=read_id,
                 chromosome=chromosome,
                 strand=strand,
@@ -144,7 +150,9 @@ def _collect_intron_retention_events(
     exons: list[Exon],
     chromosome: str,
     strand: str,
-    event_index: dict[tuple[str, str, str, Exon | None, Exon | None], SpliceEvent],
+    event_index: dict[
+        tuple[SpliceEventKind, str, str, Exon | None, Exon | None], SpliceEvent
+    ],
 ) -> None:
     for exon in exons:
         for left, right in graph.edges():
@@ -157,7 +165,7 @@ def _collect_intron_retention_events(
                 _add_event(
                     event_index=event_index,
                     event=SpliceEvent(
-                        kind=SpliceEventKind.INTRON_RETENTION.value,
+                        kind=SpliceEventKind.INTRON_RETENTION,
                         read_id=read_id,
                         chromosome=chromosome,
                         strand=strand,
@@ -169,7 +177,7 @@ def _collect_intron_retention_events(
 
 
 def _add_event(
-    event_index: dict[tuple[str, str, str, Exon | None, Exon | None], SpliceEvent],
+    event_index: dict[tuple[SpliceEventKind, str, str, Exon | None, Exon | None], SpliceEvent],
     event: SpliceEvent,
 ) -> None:
     key = (event.kind, event.read_id, event.detail, event.anchor_left, event.anchor_right)

--- a/tapis/topology/graph.py
+++ b/tapis/topology/graph.py
@@ -89,7 +89,8 @@ def extract_read_exons_from_bam(
                 continue
             if read.query_name is None:
                 continue
-            transcripts[read.query_name] = normalize_exons(blocks)
+            exons_one_based = [(start + 1, end) for start, end in blocks]
+            transcripts[read.query_name] = normalize_exons(exons_one_based)
     return transcripts
 
 

--- a/tapis/topology/reporting.py
+++ b/tapis/topology/reporting.py
@@ -2,21 +2,37 @@ from __future__ import annotations
 
 from collections import Counter
 from pathlib import Path
+from typing import Mapping, Sequence
 
 from tapis.topology.enums import SpliceEventKind
-from tapis.topology.events import detect_splice_events
-from tapis.topology.graph import build_annotation_graph, parse_gtf_exons
+from tapis.topology.events import SpliceEvent, detect_splice_events
+from tapis.topology.graph import (
+    Exon,
+    build_annotation_graph,
+    extract_read_exons_from_bam,
+    parse_gtf_exons,
+)
 
 EVENT_ORDER = (
-    SpliceEventKind.INTRON_RETENTION.value,
-    SpliceEventKind.EXON_SKIPPING.value,
-    SpliceEventKind.ALTERNATIVE_SPLICE_SITE.value,
+    SpliceEventKind.INTRON_RETENTION,
+    SpliceEventKind.EXON_SKIPPING,
+    SpliceEventKind.ALTERNATIVE_SPLICE_SITE,
 )
 
 
-def compute_as_statistics_from_gtf(gtf_path: str | Path) -> Counter[str]:
+def compute_events_from_transcripts(
+    annotation_transcripts: Mapping[str, Sequence[Exon]],
+    observed_transcripts: Mapping[str, Sequence[Exon]],
+    chromosome: str,
+    strand: str,
+) -> list[SpliceEvent]:
+    graph = build_annotation_graph(annotation_transcripts, chromosome=chromosome, strand=strand)
+    return detect_splice_events(graph, observed_transcripts)
+
+
+def compute_as_statistics_from_gtf(gtf_path: str | Path) -> Counter[SpliceEventKind]:
     transcripts = parse_gtf_exons(gtf_path)
-    counts: Counter[str] = Counter()
+    counts: Counter[SpliceEventKind] = Counter()
     if len(transcripts) <= 1:
         return counts
 
@@ -27,8 +43,12 @@ def compute_as_statistics_from_gtf(gtf_path: str | Path) -> Counter[str]:
         for transcript_id, exons in transcripts.items()
         if transcript_id != canonical_transcript_id
     }
-    graph = build_annotation_graph(canonical, chromosome="gtf", strand="+")
-    events = detect_splice_events(graph, observed)
+    events = compute_events_from_transcripts(
+        annotation_transcripts=canonical,
+        observed_transcripts=observed,
+        chromosome="gtf",
+        strand="+",
+    )
     for event in events:
         counts[event.kind] += 1
     return counts
@@ -40,8 +60,42 @@ def write_as_statistics_from_gtf(gtf_path: str | Path, output_path: str | Path) 
     output.parent.mkdir(parents=True, exist_ok=True)
     with output.open("w", encoding="utf-8") as handle:
         handle.write("event\tcount\n")
-        for event_name in EVENT_ORDER:
-            handle.write(f"{event_name}\t{counts.get(event_name, 0)}\n")
+        for event_kind in EVENT_ORDER:
+            handle.write(f"{event_kind.value}\t{counts.get(event_kind, 0)}\n")
+
+
+def write_event_table(events: Sequence[SpliceEvent], output_path: str | Path) -> None:
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    ordered_events = sorted(
+        events,
+        key=lambda event: (event.kind.value, event.read_id, event.detail),
+    )
+    with output.open("w", encoding="utf-8") as handle:
+        handle.write("kind\tread_id\tchromosome\tstrand\tdetail\n")
+        for event in ordered_events:
+            handle.write(
+                f"{event.kind.value}\t{event.read_id}\t"
+                f"{event.chromosome}\t{event.strand}\t{event.detail}\n"
+            )
+
+
+def write_event_table_from_gtf_and_bam(
+    gtf_path: str | Path,
+    bam_path: str | Path,
+    output_path: str | Path,
+    min_mapq: int = 0,
+) -> None:
+    transcripts = parse_gtf_exons(gtf_path)
+    observed = extract_read_exons_from_bam(bam_path, min_mapq=min_mapq)
+    chromosome, strand = _infer_reference_context_from_gtf(gtf_path)
+    events = compute_events_from_transcripts(
+        annotation_transcripts=transcripts,
+        observed_transcripts=observed,
+        chromosome=chromosome,
+        strand=strand,
+    )
+    write_event_table(events, output_path)
 
 
 def _select_canonical_transcript(transcripts: dict[str, list[tuple[int, int]]]) -> str:
@@ -51,3 +105,17 @@ def _select_canonical_transcript(transcripts: dict[str, list[tuple[int, int]]]) 
         return (len(exons), span, transcript_id)
 
     return max(transcripts.items(), key=_key)[0]
+
+
+def _infer_reference_context_from_gtf(gtf_path: str | Path) -> tuple[str, str]:
+    for raw_line in Path(gtf_path).read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        fields = line.split("\t")
+        if len(fields) != 9:
+            continue
+        chromosome = fields[0]
+        strand = fields[6] if fields[6] in {"+", "-"} else "+"
+        return chromosome, strand
+    return "unknown", "+"

--- a/tests/test_topology_bam_integration.py
+++ b/tests/test_topology_bam_integration.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pysam
+
+from tapis.topology.enums import SpliceEventKind
+from tapis.topology.reporting import write_event_table_from_gtf_and_bam
+
+
+def _write_read(
+    out: pysam.AlignmentFile,
+    name: str,
+    reference_start: int,
+    cigar: list[tuple[int, int]],
+    query_length: int,
+) -> None:
+    read = pysam.AlignedSegment()
+    read.query_name = name
+    read.query_sequence = "A" * query_length
+    read.flag = 0
+    read.reference_id = 0
+    read.reference_start = reference_start
+    read.mapping_quality = 60
+    read.cigar = cigar
+    read.query_qualities = pysam.qualitystring_to_array("I" * query_length)
+    out.write(read)
+
+
+def test_write_event_table_from_gtf_and_bam(tmp_path: Path) -> None:
+    gtf_path = tmp_path / "annotations.gtf"
+    gtf_path.write_text(
+        "\n".join(
+            [
+                (
+                    "chr1\ttapis\texon\t100\t149\t.\t+\t.\t"
+                    'gene_id "g1"; transcript_id "tx_ref"; exon_number "1";'
+                ),
+                (
+                    "chr1\ttapis\texon\t200\t249\t.\t+\t.\t"
+                    'gene_id "g1"; transcript_id "tx_ref"; exon_number "2";'
+                ),
+                (
+                    "chr1\ttapis\texon\t300\t349\t.\t+\t.\t"
+                    'gene_id "g1"; transcript_id "tx_ref"; exon_number "3";'
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    bam_path = tmp_path / "reads.bam"
+    header = {"HD": {"VN": "1.0"}, "SQ": [{"SN": "chr1", "LN": 1000}]}
+    with pysam.AlignmentFile(str(bam_path), "wb", header=header) as out:
+        # Exon-skipping read: exon1 -> exon3
+        _write_read(
+            out=out,
+            name="read_skip",
+            reference_start=99,
+            cigar=[(0, 50), (3, 150), (0, 50)],
+            query_length=100,
+        )
+        # Intron-retention read covering exon1+intron+exon2
+        _write_read(
+            out=out,
+            name="read_ir",
+            reference_start=99,
+            cigar=[(0, 150)],
+            query_length=150,
+        )
+
+    out_path = tmp_path / "AS_events.tsv"
+    write_event_table_from_gtf_and_bam(gtf_path=gtf_path, bam_path=bam_path, output_path=out_path)
+
+    lines = out_path.read_text(encoding="utf-8").strip().splitlines()
+    assert lines[0] == "kind\tread_id\tchromosome\tstrand\tdetail"
+    body = "\n".join(lines[1:])
+    assert SpliceEventKind.EXON_SKIPPING.value in body
+    assert SpliceEventKind.INTRON_RETENTION.value in body

--- a/tests/test_topology_engine.py
+++ b/tests/test_topology_engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from tapis.topology.enums import SpliceEventKind
 from tapis.topology.events import detect_splice_events
 from tapis.topology.graph import build_annotation_graph
 
@@ -16,8 +17,8 @@ def test_detects_exon_skipping_and_intron_retention() -> None:
     events = detect_splice_events(graph, observed)
 
     kinds = {(event.kind, event.detail) for event in events}
-    assert ("exon_skipping", "200-250") in kinds
-    assert ("intron_retention", "151-199") in kinds
+    assert (SpliceEventKind.EXON_SKIPPING, "200-250") in kinds
+    assert (SpliceEventKind.INTRON_RETENTION, "151-199") in kinds
 
 
 def test_detects_alternative_splice_site() -> None:
@@ -31,4 +32,4 @@ def test_detects_alternative_splice_site() -> None:
     events = detect_splice_events(graph, observed)
 
     kinds = {(event.kind, event.detail) for event in events}
-    assert ("alternative_splice_site", "151-210") in kinds
+    assert (SpliceEventKind.ALTERNATIVE_SPLICE_SITE, "151-210") in kinds

--- a/tests/test_topology_reporting.py
+++ b/tests/test_topology_reporting.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tapis.topology.enums import SpliceEventKind
 from tapis.topology.reporting import write_as_statistics_from_gtf
 
 
@@ -41,4 +42,4 @@ def test_writes_as_statistics_from_gtf(tmp_path: Path) -> None:
 
     lines = out_path.read_text(encoding="utf-8").strip().splitlines()
     assert lines[0] == "event\tcount"
-    assert any(line.startswith("exon_skipping\t") for line in lines[1:])
+    assert any(line.startswith(f"{SpliceEventKind.EXON_SKIPPING.value}\t") for line in lines[1:])


### PR DESCRIPTION
## Summary
- Adds BAM+GTF event-table reporting API: write_event_table_from_gtf_and_bam
- Emits AS_events.tsv from scripts/run_tapis.py using TAPIS-native topology APIs
- Converts topology event kind handling to enum-backed values end-to-end
- Adds BAM integration test validating exon-skipping and intron-retention detection

## Linked Issues
- closes #20
- references #3

## Verification
- uv run pytest -q
- uv run python -m py_compile scripts/*.py
- uv run mypy --strict tapis
- uv run python scripts/run_tapis.py --help

## Notes
- This PR is a post-merge follow-on to PR #19 and contains only the remaining delta commit.
